### PR TITLE
Feature/manual user add (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ php artisan ab:reset
 
 In addition you can hook into two events:
 
-- `ExperimentNewVisitor` gets triggered once an experiment gets assigned to a new visitor. You can grab the experiment and visitor instance as propeerties of the event.
+- `ExperimentNewVisitor` gets triggered once an experiment gets assigned to a new visitor. You can grab the experiment and visitor instance as properties of the event.
 - `GoalCompleted` gets triggered once a goal is completed. You can grab the goal as a property of the event.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ To get all completed goals for the current session:
 AbTesting::getCompletedGoals()
 ```
 
+### Persisting visitor data
+When used in the above way the visitor data is stored in session data attached to the user. In some cases you might want to trigger a goal completion in an asynchronous way and the users session won't be available. To avoid getting bad data by registering the goal completion under a new experiment you can persist the visitor data in the database.
+
+To do this you pass a user identifier to the pageview function.
+
+```php
+AbTesting::pageview($identifier)
+```
+
+In your asynchronous request you can then provide the same idenfier to the completeGoals function.
+
+```php
+AbTesting::completeGoal('payment-completed', $identifier)
+```
+
 ### Report
 
 To get a report of the page views, completed goals and conversion call the report command:
@@ -160,7 +175,7 @@ php artisan ab:reset
 
 In addition you can hook into two events:
 
-- `ExperimentNewVisitor` gets triggered once an experiment gets assigned to a new visitor. You can grab the experiment as a property of the event.
+- `ExperimentNewVisitor` gets triggered once an experiment gets assigned to a new visitor. You can grab the experiment and visitor instance as propeerties of the event.
 - `GoalCompleted` gets triggered once a goal is completed. You can grab the goal as a property of the event.
 
 ### Testing

--- a/database/migrations/2019_07_31_214643_create_visitors_table.php
+++ b/database/migrations/2019_07_31_214643_create_visitors_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateVisitorsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('ab_visitors', function (Blueprint $table) {
+            $table->integer('visitor_id')->primary();
+            $table->integer('experiment_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('ab_visitors');
+    }
+}

--- a/src/AbTesting.php
+++ b/src/AbTesting.php
@@ -2,15 +2,15 @@
 
 namespace Ben182\AbTesting;
 
-use Illuminate\Support\Collection;
 use Ben182\AbTesting\Models\Goal;
+use Illuminate\Support\Collection;
 use Ben182\AbTesting\Models\Experiment;
-use Ben182\AbTesting\Models\DatabaseVisitor;
-use Ben182\AbTesting\Models\SessionVisitor;
 use Ben182\AbTesting\Events\GoalCompleted;
+use Ben182\AbTesting\Models\SessionVisitor;
+use Ben182\AbTesting\Models\DatabaseVisitor;
+use Ben182\AbTesting\Contracts\VisitorInterface;
 use Ben182\AbTesting\Events\ExperimentNewVisitor;
 use Ben182\AbTesting\Exceptions\InvalidConfiguration;
-use Ben182\AbTesting\Contracts\VisitorInterface;
 
 class AbTesting
 {
@@ -63,7 +63,7 @@ class AbTesting
         ]);
     }
 
-   /**
+    /**
      * Resets the visitor data.
      *
      * @return void
@@ -77,7 +77,7 @@ class AbTesting
     /**
      * Triggers a new visitor. Picks a new experiment and saves it to the Visitor.
      *
-     * @param integer $visitor_id An optional visitor identifier
+     * @param int $visitor_id An optional visitor identifier
      *
      * @return \Ben182\AbTesting\Models\Experiment|void
      */
@@ -113,7 +113,7 @@ class AbTesting
     /**
      * Calculates a new experiment.
      *
-     * @return \Ben182\AbTesting\Models\Experiment|null
+     * @return \Ben182\AbTesting\Models\Experiment
      */
     protected function getNextExperiment()
     {
@@ -140,7 +140,7 @@ class AbTesting
      * Completes a goal by incrementing the hit property of the model and setting its ID in the session.
      *
      * @param string $goal The goals name
-     * @param integer $visitor_id An optional visitor identifier
+     * @param int $visitor_id An optional visitor identifier
      *
      * @return \Ben182\AbTesting\Models\Goal|false
      */
@@ -169,7 +169,7 @@ class AbTesting
     /**
      * Returns the currently active experiment.
      *
-     * @param integer $visitor_id An optional visitor identifier
+     * @param int $visitor_id An optional visitor identifier
      *
      * @return \Ben182\AbTesting\Models\Experiment|null
      */
@@ -180,8 +180,6 @@ class AbTesting
 
     /**
      * Returns all the completed goals.
-     *
-     * @param integer $visitor_id An optional visitor identifier
      *
      * @return \Illuminate\Support\Collection|false
      */
@@ -199,17 +197,17 @@ class AbTesting
     /**
      * Returns a visitor instance.
      *
-     * @param integer $visitor_id An optional visitor identifier
+     * @param int $visitor_id An optional visitor identifier
      *
      * @return \Ben182\AbTesting\Models\SessionVisitor|\Ben182\AbTesting\Models\DatabaseVisitor
      */
     public function getVisitor($visitor_id = null)
     {
-        if ( !is_null($this->visitor) ) {
+        if (! is_null($this->visitor)) {
             return $this->visitor;
         }
 
-        if ($visitor_id) {
+        if (! empty($visitor_id)) {
             return $this->visitor = DatabaseVisitor::firstOrNew(['visitor_id' => $visitor_id]);
         } else {
             return $this->visitor = new SessionVisitor();

--- a/src/AbTesting.php
+++ b/src/AbTesting.php
@@ -2,18 +2,21 @@
 
 namespace Ben182\AbTesting;
 
-use Ben182\AbTesting\Models\Goal;
 use Illuminate\Support\Collection;
+use Ben182\AbTesting\Models\Goal;
 use Ben182\AbTesting\Models\Experiment;
+use Ben182\AbTesting\Models\DatabaseVisitor;
+use Ben182\AbTesting\Models\SessionVisitor;
 use Ben182\AbTesting\Events\GoalCompleted;
 use Ben182\AbTesting\Events\ExperimentNewVisitor;
 use Ben182\AbTesting\Exceptions\InvalidConfiguration;
+use Ben182\AbTesting\Contracts\VisitorInterface;
 
 class AbTesting
 {
     protected $experiments;
+    protected $visitor;
 
-    const SESSION_KEY_EXPERIMENT = 'ab_testing_experiment';
     const SESSION_KEY_GOALS = 'ab_testing_goals';
 
     public function __construct()
@@ -60,36 +63,51 @@ class AbTesting
         ]);
     }
 
+   /**
+     * Resets the visitor data.
+     *
+     * @return void
+     */
+    public function resetVisitor()
+    {
+        session()->flush();
+        $this->visitor = null;
+    }
+
     /**
-     * Triggers a new visitor. Picks a new experiment and saves it to the session.
+     * Triggers a new visitor. Picks a new experiment and saves it to the Visitor.
+     *
+     * @param integer $visitor_id An optional visitor identifier
      *
      * @return \Ben182\AbTesting\Models\Experiment|void
      */
-    public function pageView()
+    public function pageView($visitor_id = null)
     {
-        if (! session(self::SESSION_KEY_EXPERIMENT)) {
-            $this->start();
-            $this->setNextExperiment();
+        $visitor = $this->getVisitor($visitor_id);
 
-            event(new ExperimentNewVisitor($this->getExperiment()));
+        if (! session(self::SESSION_KEY_GOALS)) {
+            $this->start();
+            $this->setNextExperiment($visitor);
+
+            event(new ExperimentNewVisitor($this->getExperiment(), $visitor));
 
             return $this->getExperiment();
         }
     }
 
     /**
-     * Calculates a new experiment and sets it to the session.
+     * Calculates a new experiment and sets it to the Visitor.
+     *
+     * @param VisitorInterface $visitor An object implementing VisitorInterface
      *
      * @return void
      */
-    protected function setNextExperiment()
+    protected function setNextExperiment(VisitorInterface $visitor)
     {
         $next = $this->getNextExperiment();
         $next->incrementVisitor();
 
-        session([
-            self::SESSION_KEY_EXPERIMENT => $next,
-        ]);
+        $visitor->setExperiment($next);
     }
 
     /**
@@ -122,16 +140,15 @@ class AbTesting
      * Completes a goal by incrementing the hit property of the model and setting its ID in the session.
      *
      * @param string $goal The goals name
+     * @param integer $visitor_id An optional visitor identifier
      *
      * @return \Ben182\AbTesting\Models\Goal|false
      */
-    public function completeGoal(string $goal)
+    public function completeGoal(string $goal, $visitor_id = null)
     {
-        if (! $this->getExperiment()) {
-            $this->pageView();
-        }
+        $this->pageView($visitor_id);
 
-        $goal = $this->getExperiment()->goals->where('name', $goal)->first();
+        $goal = $this->getExperiment($visitor_id)->goals->where('name', $goal)->first();
 
         if (! $goal) {
             return false;
@@ -152,15 +169,19 @@ class AbTesting
     /**
      * Returns the currently active experiment.
      *
+     * @param integer $visitor_id An optional visitor identifier
+     *
      * @return \Ben182\AbTesting\Models\Experiment|null
      */
-    public function getExperiment()
+    public function getExperiment($visitor_id = null)
     {
-        return session(self::SESSION_KEY_EXPERIMENT);
+        return $this->getVisitor($visitor_id)->getExperiment();
     }
 
     /**
      * Returns all the completed goals.
+     *
+     * @param integer $visitor_id An optional visitor identifier
      *
      * @return \Illuminate\Support\Collection|false
      */
@@ -173,5 +194,25 @@ class AbTesting
         return session(self::SESSION_KEY_GOALS)->map(function ($goalId) {
             return Goal::find($goalId);
         });
+    }
+
+    /**
+     * Returns a visitor instance.
+     *
+     * @param integer $visitor_id An optional visitor identifier
+     *
+     * @return \Ben182\AbTesting\Models\SessionVisitor|\Ben182\AbTesting\Models\DatabaseVisitor
+     */
+    public function getVisitor($visitor_id = null)
+    {
+        if ( !is_null($this->visitor) ) {
+            return $this->visitor;
+        }
+
+        if ($visitor_id) {
+            return $this->visitor = DatabaseVisitor::firstOrNew(['visitor_id' => $visitor_id]);
+        } else {
+            return $this->visitor = new SessionVisitor();
+        }
     }
 }

--- a/src/AbTesting.php
+++ b/src/AbTesting.php
@@ -85,14 +85,19 @@ class AbTesting
     {
         $visitor = $this->getVisitor($visitor_id);
 
-        if (! session(self::SESSION_KEY_GOALS)) {
+        if (! session(self::SESSION_KEY_GOALS) || $this->experiments->isEmpty()) {
             $this->start();
-            $this->setNextExperiment($visitor);
-
-            event(new ExperimentNewVisitor($this->getExperiment(), $visitor));
-
-            return $this->getExperiment();
         }
+
+        if ( $visitor->hasExperiment() ) {
+            return $visitor->getExperiment();
+        }
+
+        $this->setNextExperiment($visitor);
+
+        event(new ExperimentNewVisitor($this->getExperiment(), $visitor));
+
+        return $this->getExperiment();
     }
 
     /**

--- a/src/AbTesting.php
+++ b/src/AbTesting.php
@@ -89,7 +89,7 @@ class AbTesting
             $this->start();
         }
 
-        if ( $visitor->hasExperiment() ) {
+        if ($visitor->hasExperiment()) {
             return $visitor->getExperiment();
         }
 

--- a/src/Commands/ResetCommand.php
+++ b/src/Commands/ResetCommand.php
@@ -7,7 +7,6 @@ use Ben182\AbTesting\Models\Goal;
 use Ben182\AbTesting\Models\Experiment;
 use Ben182\AbTesting\Models\DatabaseVisitor;
 
-
 class ResetCommand extends Command
 {
     /**

--- a/src/Commands/ResetCommand.php
+++ b/src/Commands/ResetCommand.php
@@ -5,6 +5,8 @@ namespace Ben182\AbTesting\Commands;
 use Illuminate\Console\Command;
 use Ben182\AbTesting\Models\Goal;
 use Ben182\AbTesting\Models\Experiment;
+use Ben182\AbTesting\Models\DatabaseVisitor;
+
 
 class ResetCommand extends Command
 {
@@ -41,6 +43,7 @@ class ResetCommand extends Command
     {
         Goal::truncate();
         Experiment::truncate();
+        DatabaseVisitor::truncate();
 
         $this->info('Successfully deleted all experiment visitors and goal completions.');
     }

--- a/src/Contracts/VisitorInterface.php
+++ b/src/Contracts/VisitorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Ben182\AbTesting\Contracts;
+
+use Ben182\AbTesting\Models\Experiment;
+
+interface VisitorInterface
+{
+    public function hasExperiment();
+    public function getExperiment();
+    public function setExperiment(Experiment $experiment);
+}

--- a/src/Contracts/VisitorInterface.php
+++ b/src/Contracts/VisitorInterface.php
@@ -7,6 +7,8 @@ use Ben182\AbTesting\Models\Experiment;
 interface VisitorInterface
 {
     public function hasExperiment();
+
     public function getExperiment();
+
     public function setExperiment(Experiment $experiment);
 }

--- a/src/Events/ExperimentNewVisitor.php
+++ b/src/Events/ExperimentNewVisitor.php
@@ -7,6 +7,7 @@ use Ben182\AbTesting\Contracts\VisitorInterface;
 class ExperimentNewVisitor
 {
     public $experiment;
+    public $visitor;
 
     public function __construct($experiment, VisitorInterface $visitor)
     {

--- a/src/Events/ExperimentNewVisitor.php
+++ b/src/Events/ExperimentNewVisitor.php
@@ -2,12 +2,15 @@
 
 namespace Ben182\AbTesting\Events;
 
+use Ben182\AbTesting\Contracts\VisitorInterface;
+
 class ExperimentNewVisitor
 {
     public $experiment;
 
-    public function __construct($experiment)
+    public function __construct($experiment, VisitorInterface $visitor)
     {
         $this->experiment = $experiment;
+        $this->visitor = $visitor;
     }
 }

--- a/src/Models/DatabaseVisitor.php
+++ b/src/Models/DatabaseVisitor.php
@@ -29,7 +29,8 @@ class DatabaseVisitor extends Model implements VisitorInterface
         return $this->experiment;
     }
 
-    public function setExperiment(Experiment $next) {
+    public function setExperiment(Experiment $next)
+    {
         $this->experiment_id = $next->id;
         $this->save();
     }

--- a/src/Models/DatabaseVisitor.php
+++ b/src/Models/DatabaseVisitor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ben182\AbTesting\Models;
+
+use Ben182\AbTesting\Contracts\VisitorInterface;
+use Ben182\AbTesting\Models\Experiment;
+use Illuminate\Database\Eloquent\Model;
+
+class DatabaseVisitor extends Model implements VisitorInterface
+{
+    protected $primaryKey = 'visitor_id';
+    protected $table = 'ab_visitors';
+    protected $fillable = [
+        'visitor_id',
+        'experiment_id',
+    ];
+
+    public function experiment()
+    {
+        return $this->belongsTo(Experiment::class);
+    }
+
+    public function hasExperiment() {
+        return !is_null($this->experiment_id) && $this->experiment_id;
+    }
+
+    public function getExperiment() {
+        return $this->experiment;
+    }
+
+    public function setExperiment(Experiment $next) {
+        $this->experiment_id = $next->id;
+        $this->save();
+    }
+}

--- a/src/Models/DatabaseVisitor.php
+++ b/src/Models/DatabaseVisitor.php
@@ -2,9 +2,8 @@
 
 namespace Ben182\AbTesting\Models;
 
-use Ben182\AbTesting\Contracts\VisitorInterface;
-use Ben182\AbTesting\Models\Experiment;
 use Illuminate\Database\Eloquent\Model;
+use Ben182\AbTesting\Contracts\VisitorInterface;
 
 class DatabaseVisitor extends Model implements VisitorInterface
 {
@@ -20,11 +19,13 @@ class DatabaseVisitor extends Model implements VisitorInterface
         return $this->belongsTo(Experiment::class);
     }
 
-    public function hasExperiment() {
-        return !is_null($this->experiment_id) && $this->experiment_id;
+    public function hasExperiment()
+    {
+        return ! is_null($this->experiment_id) && $this->experiment_id;
     }
 
-    public function getExperiment() {
+    public function getExperiment()
+    {
         return $this->experiment;
     }
 

--- a/src/Models/SessionVisitor.php
+++ b/src/Models/SessionVisitor.php
@@ -3,21 +3,23 @@
 namespace Ben182\AbTesting\Models;
 
 use Ben182\AbTesting\Contracts\VisitorInterface;
-use Ben182\AbTesting\Models\Experiment;
 
 class SessionVisitor implements VisitorInterface
 {
     const SESSION_KEY_EXPERIMENT = 'ab_testing_experiment';
 
-    public function hasExperiment() {
+    public function hasExperiment()
+    {
         return (bool)session(self::SESSION_KEY_EXPERIMENT);
     }
 
-    public function getExperiment() {
+    public function getExperiment()
+    {
         return session(self::SESSION_KEY_EXPERIMENT);
     }
 
-    public function setExperiment(Experiment $next) {
+    public function setExperiment(Experiment $next)
+    {
         session([self::SESSION_KEY_EXPERIMENT => $next]);
     }
 }

--- a/src/Models/SessionVisitor.php
+++ b/src/Models/SessionVisitor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Ben182\AbTesting\Models;
+
+use Ben182\AbTesting\Contracts\VisitorInterface;
+use Ben182\AbTesting\Models\Experiment;
+
+class SessionVisitor implements VisitorInterface
+{
+    const SESSION_KEY_EXPERIMENT = 'ab_testing_experiment';
+
+    public function hasExperiment() {
+        return (bool)session(self::SESSION_KEY_EXPERIMENT);
+    }
+
+    public function getExperiment() {
+        return session(self::SESSION_KEY_EXPERIMENT);
+    }
+
+    public function setExperiment(Experiment $next) {
+        session([self::SESSION_KEY_EXPERIMENT => $next]);
+    }
+}

--- a/src/Models/SessionVisitor.php
+++ b/src/Models/SessionVisitor.php
@@ -10,7 +10,7 @@ class SessionVisitor implements VisitorInterface
 
     public function hasExperiment()
     {
-        return (bool)session(self::SESSION_KEY_EXPERIMENT);
+        return (bool) session(self::SESSION_KEY_EXPERIMENT);
     }
 
     public function getExperiment()

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -2,27 +2,33 @@
 
 namespace Ben182\AbTesting\Tests;
 
-use Ben182\AbTesting\Models\Goal;
 use Ben182\AbTesting\AbTestingFacade;
+use Ben182\AbTesting\Models\Goal;
 use Ben182\AbTesting\Models\Experiment;
+use Ben182\AbTesting\Models\DatabaseVisitor;
 use Ben182\AbTesting\Commands\ReportCommand;
 
 class CommandTest extends TestCase
 {
     public function test_flush_command()
     {
+        DatabaseVisitor::truncate();
+
         $this->assertCount(0, Experiment::all());
         $this->assertCount(0, Goal::all());
+        $this->assertCount(0, DatabaseVisitor::all());
 
-        AbTestingFacade::pageView();
+        AbTestingFacade::pageView(123);
 
         $this->assertCount(2, Experiment::all());
         $this->assertCount(4, Goal::all());
+        $this->assertCount(1, DatabaseVisitor::all());
 
         $this->artisan('ab:reset');
 
         $this->assertCount(0, Experiment::all());
         $this->assertCount(0, Goal::all());
+        $this->assertCount(0, DatabaseVisitor::all());
     }
 
     public function test_report_command()

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -2,11 +2,11 @@
 
 namespace Ben182\AbTesting\Tests;
 
-use Ben182\AbTesting\AbTestingFacade;
 use Ben182\AbTesting\Models\Goal;
+use Ben182\AbTesting\AbTestingFacade;
 use Ben182\AbTesting\Models\Experiment;
-use Ben182\AbTesting\Models\DatabaseVisitor;
 use Ben182\AbTesting\Commands\ReportCommand;
+use Ben182\AbTesting\Models\DatabaseVisitor;
 
 class CommandTest extends TestCase
 {

--- a/tests/GoalTest.php
+++ b/tests/GoalTest.php
@@ -6,7 +6,6 @@ use Ben182\AbTesting\AbTesting;
 use Ben182\AbTesting\AbTestingFacade;
 use Illuminate\Support\Facades\Event;
 use Ben182\AbTesting\Events\GoalCompleted;
-use Ben182\AbTesting\Models\SessionVisitor;
 
 class GoalTest extends TestCase
 {

--- a/tests/PageViewTest.php
+++ b/tests/PageViewTest.php
@@ -2,12 +2,11 @@
 
 namespace Ben182\AbTesting\Tests;
 
-use Ben182\AbTesting\AbTesting;
 use Ben182\AbTesting\AbTestingFacade;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
-use Ben182\AbTesting\Events\ExperimentNewVisitor;
 use Ben182\AbTesting\Models\SessionVisitor;
+use Ben182\AbTesting\Events\ExperimentNewVisitor;
 
 class PageViewTest extends TestCase
 {

--- a/tests/PageViewTest.php
+++ b/tests/PageViewTest.php
@@ -7,6 +7,7 @@ use Ben182\AbTesting\AbTestingFacade;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Ben182\AbTesting\Events\ExperimentNewVisitor;
+use Ben182\AbTesting\Models\SessionVisitor;
 
 class PageViewTest extends TestCase
 {
@@ -14,7 +15,7 @@ class PageViewTest extends TestCase
     {
         AbTestingFacade::pageView();
 
-        $experiment = session(AbTesting::SESSION_KEY_EXPERIMENT);
+        $experiment = session(SessionVisitor::SESSION_KEY_EXPERIMENT);
 
         $this->assertEquals($this->experiments[0], $experiment->name);
         $this->assertEquals(1, $experiment->visitors);
@@ -30,11 +31,11 @@ class PageViewTest extends TestCase
 
         session()->flush();
 
-        $this->assertNull(session(AbTesting::SESSION_KEY_EXPERIMENT));
+        $this->assertNull(session(SessionVisitor::SESSION_KEY_EXPERIMENT));
 
         AbTestingFacade::pageView();
 
-        $experiment = session(AbTesting::SESSION_KEY_EXPERIMENT);
+        $experiment = session(SessionVisitor::SESSION_KEY_EXPERIMENT);
 
         $this->assertEquals($this->experiments[1], $experiment->name);
         $this->assertEquals(1, $experiment->visitors);
@@ -55,7 +56,7 @@ class PageViewTest extends TestCase
         AbTestingFacade::pageView();
         AbTestingFacade::pageView();
 
-        $experiment = session(AbTesting::SESSION_KEY_EXPERIMENT);
+        $experiment = session(SessionVisitor::SESSION_KEY_EXPERIMENT);
 
         $this->assertEquals(1, $experiment->visitors);
     }
@@ -64,7 +65,7 @@ class PageViewTest extends TestCase
     {
         AbTestingFacade::isExperiment('firstExperiment');
 
-        $experiment = session(AbTesting::SESSION_KEY_EXPERIMENT);
+        $experiment = session(SessionVisitor::SESSION_KEY_EXPERIMENT);
 
         $this->assertEquals($this->experiments[0], $experiment->name);
         $this->assertEquals(1, $experiment->visitors);
@@ -74,7 +75,7 @@ class PageViewTest extends TestCase
     {
         $this->newVisitor();
 
-        $experiment = session(AbTesting::SESSION_KEY_EXPERIMENT);
+        $experiment = session(SessionVisitor::SESSION_KEY_EXPERIMENT);
 
         $this->assertEquals($experiment, request()->abExperiment());
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,6 @@ namespace Ben182\AbTesting\Tests;
 use Ben182\AbTesting\AbTestingFacade;
 use Illuminate\Support\Facades\Event;
 use Ben182\AbTesting\AbTestingServiceProvider;
-use Ben182\AbTesting\Models\DatabaseVisitor;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Ben182\AbTesting\Tests;
 use Ben182\AbTesting\AbTestingFacade;
 use Illuminate\Support\Facades\Event;
 use Ben182\AbTesting\AbTestingServiceProvider;
+use Ben182\AbTesting\Models\DatabaseVisitor;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -47,7 +48,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function newVisitor()
     {
-        session()->flush();
+        AbTestingFacade::resetVisitor();
         AbTestingFacade::pageView();
     }
 }


### PR DESCRIPTION
* Add feature for server side visitor data storage

When goals are completed asynchronously there is currently no way to tie
that completion to the experiment that triggered it. This feature adds
support for server side storage of which experiment a visitor is seeing
by allowing a visitor ID to be passed and persisted in the database.