### PR TITLE
Update how the package ignores bots and crawlers

### DIFF
--- a/src/AbTesting.php
+++ b/src/AbTesting.php
@@ -180,7 +180,7 @@ class AbTesting
     /**
      * Check if the current request is from a crawler or bot and config option is enabled.
      *
-     * @return boolean
+     * @return bool
      */
     public function isCrawler()
     {

--- a/src/AbTesting.php
+++ b/src/AbTesting.php
@@ -185,4 +185,15 @@ class AbTesting
             return Goal::find($goalId);
         });
     }
+
+    /**
+     * Check if the current request is from a crawler or bot and config option is enabled.
+     *
+     * @return boolean
+     */
+    public function isCrawler()
+    {
+        return config('ab-testing.ignore_crawlers')
+            && (new CrawlerDetect)->isCrawler();
+    }
 }

--- a/src/Models/Experiment.php
+++ b/src/Models/Experiment.php
@@ -2,7 +2,9 @@
 
 namespace Ben182\AbTesting\Models;
 
+use Ben182\AbTesting\AbTestingFacade;
 use Illuminate\Database\Eloquent\Model;
+use Ben182\AbTesting\Events\ExperimentNewVisitor;
 
 class Experiment extends Model
 {
@@ -22,8 +24,13 @@ class Experiment extends Model
         return $this->hasMany(Goal::class);
     }
 
-    public function incrementVisitor()
+    public function visit()
     {
+        if (AbTestingFacade::isCrawler()) {
+            return;
+        }
+
         $this->increment('visitors');
+        event(new ExperimentNewVisitor($this));
     }
 }

--- a/src/Models/Goal.php
+++ b/src/Models/Goal.php
@@ -2,7 +2,9 @@
 
 namespace Ben182\AbTesting\Models;
 
+use Ben182\AbTesting\AbTestingFacade;
 use Illuminate\Database\Eloquent\Model;
+use Ben182\AbTesting\Events\GoalCompleted;
 
 class Goal extends Model
 {
@@ -22,8 +24,13 @@ class Goal extends Model
         return $this->belongsTo(Experiment::class);
     }
 
-    public function incrementHit()
+    public function complete()
     {
+        if (AbTestingFacade::isCrawler()) {
+            return;
+        }
+
         $this->increment('hit');
+        event(new GoalCompleted($this));
     }
 }

--- a/tests/GoalTest.php
+++ b/tests/GoalTest.php
@@ -45,6 +45,17 @@ class GoalTest extends TestCase
         $this->assertEquals(collect([$goal->id]), session(AbTesting::SESSION_KEY_GOALS));
     }
 
+    public function test_that_crawlers_does_not_complete_goals()
+    {
+        $this->actingAsCrawler();
+
+        $goal = AbTestingFacade::completeGoal('firstGoal');
+
+        $this->assertEquals(0, $goal->hit);
+
+        Event::assertNotDispatched(GoalCompleted::class);
+    }
+
     public function test_that_invalid_goal_name_returns_false()
     {
         $this->assertFalse(AbTestingFacade::completeGoal('1234'));

--- a/tests/PageViewTest.php
+++ b/tests/PageViewTest.php
@@ -40,14 +40,15 @@ class PageViewTest extends TestCase
         $this->assertEquals(1, $experiment->visitors);
     }
 
-    public function test_that_pageview_does_not_trigger_for_crawlers()
+    public function test_that_crawlers_does_not_trigger_pageviews()
     {
-        $_SERVER['HTTP_USER_AGENT'] = 'crawl';
-        config()->set('ab-testing.ignore_crawlers', true);
+        $this->actingAsCrawler();
 
         AbTestingFacade::pageView();
 
-        $this->assertNull(session(AbTesting::SESSION_KEY_EXPERIMENT));
+        $experiment = session(AbTesting::SESSION_KEY_EXPERIMENT);
+
+        $this->assertEquals(0, $experiment->visitors);
 
         Event::assertNotDispatched(ExperimentNewVisitor::class);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,4 +50,10 @@ class TestCase extends \Orchestra\Testbench\TestCase
         session()->flush();
         AbTestingFacade::pageView();
     }
+
+    protected function actingAsCrawler()
+    {
+        $_SERVER['HTTP_USER_AGENT'] = 'crawl';
+        config()->set('ab-testing.ignore_crawlers', true);
+    }
 }


### PR DESCRIPTION
This PR continues the work to ignore crawlers started in my previous PR. 
Now; crawlers see the experiments just like a regular visitor, but it never increments the tables in the database.

I've renamed two of your methods in this PR (on the models). Feel free to push new commits to this PR if you don't agree with this change.

## Added

- `isCrawler()` public method on AbTesting.php.
- `actingAsCrawler()` method on TestCase.php.

## Changed

- Rename `$experiment->incrementVisitor()` to `$experiment->visit()` and rename `$goal->incrementHit()` to `$goal->complete()`.
- Moved event dispatches from `AbTesting` to the methods on the models.

## Fixed

- Fixes a bug introduced in my previous PR where crawlers would get a 500 error from server when trying to load a view with AB testing if no `else` statement was given.